### PR TITLE
Max rating difference for queue matching

### DIFF
--- a/duels-plugin/src/main/java/me/realized/duels/config/Config.java
+++ b/duels-plugin/src/main/java/me/realized/duels/config/Config.java
@@ -153,6 +153,8 @@ public class Config extends AbstractConfiguration<DuelsPlugin> {
     @Getter
     private int kFactor;
     @Getter
+    private int maxDifference;
+    @Getter
     private int defaultRating;
     @Getter
     private boolean ratingQueueOnly;
@@ -328,6 +330,7 @@ public class Config extends AbstractConfiguration<DuelsPlugin> {
 
         ratingEnabled = configuration.getBoolean("rating.enabled", true);
         kFactor = Math.max(configuration.getInt("rating.k-factor", 32), 1);
+        maxDifference = Math.max(configuration.getInt("rating.max-difference", 400), 1);
         defaultRating = Math.max(configuration.getInt("rating.default-rating", 1400), 0);
         ratingQueueOnly = configuration.getBoolean("rating.queue-matches-only", true);
 

--- a/duels-plugin/src/main/java/me/realized/duels/queue/QueueManager.java
+++ b/duels-plugin/src/main/java/me/realized/duels/queue/QueueManager.java
@@ -107,7 +107,7 @@ public class QueueManager implements Loadable, DQueueManager, Listener {
     }
 
     private boolean canFight(final Kit kit, final UserData first, final UserData second) {
-        if (kit == null || !config.isRatingEnabled()) {
+        if (!config.isRatingEnabled()) {
             return true;
         }
 
@@ -115,7 +115,8 @@ public class QueueManager implements Loadable, DQueueManager, Listener {
             final int firstRating = first.getRating(kit);
             final int secondRating = second.getRating(kit);
             final int kFactor = config.getKFactor();
-            return NumberUtil.getChange(kFactor, firstRating, secondRating) != 0 && NumberUtil.getChange(kFactor, secondRating, firstRating) != 0;
+            final int maxDifference = config.getMaxDifference();
+            return firstRating - secondRating <= maxDifference && secondRating - firstRating <= maxDifference && NumberUtil.getChange(kFactor, firstRating, secondRating) != 0 && NumberUtil.getChange(kFactor, secondRating, firstRating) != 0;
         }
 
         return false;

--- a/duels-plugin/src/main/resources/config.yml
+++ b/duels-plugin/src/main/resources/config.yml
@@ -387,6 +387,10 @@ rating:
   # default: 32
   k-factor: 32
 
+  # Max possible rating difference when matching players in queue
+  # default: 400
+  max-difference: 400
+
   # The default rating for all kits.
   # default: 1400
   default-rating: 1400


### PR DESCRIPTION
Added 'max-difference' config value to set max possible rating difference between players for queue matching