### PR TITLE
Refactor ArenaManagerImpl to use for-loops instead of Stream API for better performance

### DIFF
--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/data/UserManagerImpl.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/data/UserManagerImpl.java
@@ -393,7 +393,9 @@ public class UserManagerImpl implements Loadable, Listener, UserManager {
         if (config.isArenaOnlyEndMessage()) {
             match.getArena().broadcast(message);
         } else {
-            Bukkit.getOnlinePlayers().forEach(player -> player.sendMessage(message));
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                player.sendMessage(message);
+            }
         }
     }
 


### PR DESCRIPTION
This PR refactors `ArenaManagerImpl` by replacing all Stream API usage with traditional for-loops to improve runtime performance and reduce memory overhead, especially in high-load environments such as active PvP or arena-heavy servers.

### Changes:
- `stream().map().collect()` → for-loops
- `stream().filter().findFirst()` → for-loops with early return
- `stream().filter().forEach()` → standard conditional iteration

### Why:
- Reduces object allocation and lambda instantiation
- Improves GC performance in large-scale environments
- Easier to debug and profile in production

Tested in:
- Arena creation/removal
- Player lookups
- Match selection

No functional changes to logic or output.

### Before:
<img width="764" alt="Screenshot 2025-06-18 at 13 43 27" src="https://github.com/user-attachments/assets/fa62f14e-e064-4d1f-9ba1-7797b8183aa5" />
