### PR TITLE
Add missing ERROR.duel.prevent-teleportation message

### DIFF
--- a/duels-plugin/src/main/resources/lang.yml
+++ b/duels-plugin/src/main/resources/lang.yml
@@ -64,6 +64,7 @@ ERROR:
       sender: '{PREFIX} &cYou cannot do this while in spectator mode.'
       target: '{PREFIX} &c%name% is in spectator mode.'
     not-in-match: '{PREFIX} &c%name% is not in a duel.'
+    prevent-teleportation: '{PREFIX} &cYou cannot teleport to this player because he is in a duel.'
   party-duel:
     inventory-not-empty: '{PREFIX} &cYou and your party members must have a cleared inventory to use this command.'
     in-creative-mode: '{PREFIX} &cYou or your party member is in creative mode.'


### PR DESCRIPTION
This PR fixes the missing `[ERROR.duel.prevent-teleportation](https://github.com/dumbo-the-developer/Duels/blob/de4441a3fb1a03f3a47b1632f2643d952a843a26/duels-plugin/src/main/java/com/meteordevelopments/duels/listeners/TeleportListener.java#L61)` key in the lang file.  
Previously, the plugin logged an error when attempting to load this message, since no value was assigned.