### PR TITLE
Prevent multiple simultaneous duel acceptances

### DIFF
--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/validator/ValidatorManager.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/validator/ValidatorManager.java
@@ -91,6 +91,7 @@ public class ValidatorManager implements Loadable {
                 target(TargetCheckSelfValidator.class),
                 target(TargetPartyValidator.class),
                 target(TargetCheckMatchValidator.class),
+                target(TargetCheckSelfMatchValidator.class),
                 target(TargetCheckSpectateValidator.class),
                 target(TargetNoRequestValidator.class),
                 target(TargetPartyOwnerValidator.class)

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/validator/validators/request/target/TargetCheckSelfMatchValidator.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/validator/validators/request/target/TargetCheckSelfMatchValidator.java
@@ -1,0 +1,29 @@
+package com.meteordevelopments.duels.validator.validators.request.target;
+
+import java.util.Collection;
+import com.meteordevelopments.duels.DuelsPlugin;
+import com.meteordevelopments.duels.party.Party;
+import com.meteordevelopments.duels.util.function.Pair;
+import com.meteordevelopments.duels.validator.BaseTriValidator;
+import org.bukkit.entity.Player;
+
+
+public class TargetCheckSelfMatchValidator extends BaseTriValidator<Pair<Player, Player>, Party, Collection<Player>> {
+
+    private static final String MESSAGE_KEY = "ERROR.duel.already-in-match.sender";
+    private static final String PARTY_MESSAGE_KEY = "ERROR.party-duel.already-in-match.sender";
+
+    public TargetCheckSelfMatchValidator(final DuelsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean validate(final Pair<Player, Player> pair, final Party party, final Collection<Player> players) {
+        if (players.stream().anyMatch(player -> arenaManager.isInMatch(player))) {
+            lang.sendMessage(pair.getKey(), party != null ? PARTY_MESSAGE_KEY : MESSAGE_KEY, "name", pair.getValue().getName());
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds a new validator (`TargetCheckSelfMatchValidator`) to prevent players from accepting multiple duel requests at the same time.

### Problem
Previously, if a player had multiple pending duel requests, they could accept more than one. This could result in one player being left without an opponent and potential inventory loss.

### Solution
- Added `TargetCheckSelfMatchValidator` in `com.meteordevelopments.duels.validator.validators.request.target`.
- Registered it in `ValidatorManager` and added to `duelAcceptTargetValidators`.
- The validator checks whether the accepting player is already in a match.
- Multiple pending requests are still allowed; only accepting while in a match is blocked.

### Impact
Fixes the bug where players could accept multiple duel requests simultaneously, without limiting the number of requests that can be sent.