### PR TITLE
Fix teleportation bug when player is riding an entity

### DIFF
--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/teleport/Teleport.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/teleport/Teleport.java
@@ -1,6 +1,7 @@
 package com.meteordevelopments.duels.teleport;
 
 import com.meteordevelopments.duels.DuelsPlugin;
+import com.meteordevelopments.duels.api.event.match.MatchEndEvent;
 import com.meteordevelopments.duels.hook.hooks.EssentialsHook;
 import com.meteordevelopments.duels.util.Loadable;
 import com.meteordevelopments.duels.util.Log;
@@ -55,6 +56,10 @@ public final class Teleport implements Loadable, Listener {
 
         for (Entity entity : player.getPassengers()) {
             player.removePassenger(entity);
+        }
+
+        if (player.isInsideVehicle()) {
+            player.leaveVehicle();
         }
 
         player.closeInventory();

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/teleport/Teleport.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/teleport/Teleport.java
@@ -1,7 +1,6 @@
 package com.meteordevelopments.duels.teleport;
 
 import com.meteordevelopments.duels.DuelsPlugin;
-import com.meteordevelopments.duels.api.event.match.MatchEndEvent;
 import com.meteordevelopments.duels.hook.hooks.EssentialsHook;
 import com.meteordevelopments.duels.util.Loadable;
 import com.meteordevelopments.duels.util.Log;


### PR DESCRIPTION
Fixes an issue where player riding entities (horse, boats, etc..) would receive duel kit items but fail to teleport to the arena.
This fix ensures players are ejected from any vehicle they are riding.