### PR TITLE
Add `/duel leave` command to allow players to forfeit ongoing duels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     group = 'com.meteordevelopments'
-    version = '7.2'
+    version = '7.4'
 }
 
 subprojects {

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/DuelsPlugin.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/DuelsPlugin.java
@@ -198,11 +198,11 @@ public class DuelsPlugin extends JavaPlugin implements Duels, LogSource {
         unregisterPluginCommands();
         registeredListeners.forEach(HandlerList::unregisterAll);
         registeredListeners.clear();
-        // Unregister all extension listeners that isn't using the method Duels#registerListener
+        // Unregister all extension listeners that aren't using Duels#registerListener
         HandlerList.getRegisteredListeners(this)
-                .stream()
-                .filter(listener -> listener.getListener().getClass().getClassLoader().getClass().isAssignableFrom(ExtensionClassLoader.class))
-                .forEach(listener -> HandlerList.unregisterAll(listener.getListener()));
+            .stream()
+            .filter(listener -> listener.getListener().getClass().getClassLoader() instanceof ExtensionClassLoader)
+            .forEach(listener -> HandlerList.unregisterAll(listener.getListener()));
         commands.clear();
 
         for (final Loadable loadable : Lists.reverse(loadables)) {
@@ -482,6 +482,9 @@ public class DuelsPlugin extends JavaPlugin implements Duels, LogSource {
             return false;
         }
 
+        registerAllCommands();
+        loadPreListeners();
+
         return true;
     }
 
@@ -703,8 +706,8 @@ public class DuelsPlugin extends JavaPlugin implements Duels, LogSource {
         sendMessage("&eLoading extensions...");
         try {
             loadables.add(extensionManager = new ExtensionManager(this));
-            extensionManager.handleLoad();
             lastLoad = loadables.indexOf(extensionManager);
+            extensionManager.handleLoad();
             sendMessage("&dSuccessfully loaded extensions in &f[" + CC.getTimeDifferenceAndColor(start, System.currentTimeMillis()) + "&f]");
         } catch (Exception e) {
             sendMessage("&cFailed to load extensions: " + e.getMessage());

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/command/commands/duel/DuelCommand.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/command/commands/duel/DuelCommand.java
@@ -39,7 +39,8 @@ public class DuelCommand extends BaseCommand {
                 new ToggleCommand(plugin),
                 new TopCommand(plugin),
                 new InventoryCommand(plugin),
-                new VersionCommand(plugin)
+                new VersionCommand(plugin),
+                new LeaveCommand(plugin)
         );
         this.worldGuard = hookManager.getHook(WorldGuardHook.class);
         this.vault = hookManager.getHook(VaultHook.class);

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/command/commands/duel/subcommands/LeaveCommand.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/command/commands/duel/subcommands/LeaveCommand.java
@@ -1,0 +1,55 @@
+package com.meteordevelopments.duels.command.commands.duel.subcommands;
+
+import com.meteordevelopments.duels.DuelsPlugin;
+import com.meteordevelopments.duels.command.BaseCommand;
+import com.meteordevelopments.duels.core.arena.ArenaImpl;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class LeaveCommand extends BaseCommand {
+
+    public LeaveCommand(final DuelsPlugin plugin) {
+        super(plugin, "leave", "leave", "Surrender and forfeit the current duel.", null, 1, true, "surrender", "forfeit");
+    }
+
+    @Override
+    protected void execute(final CommandSender sender, final String label, final String[] args) {
+        final Player player = (Player) sender;
+
+        // Check if player is in a match
+        if (!arenaManager.isInMatch(player)) {
+            lang.sendMessage(player, "ERROR.duel.not-in-match", "name", player.getName());
+            return;
+        }
+
+        final ArenaImpl arena = arenaManager.get(player);
+        final var match = arena.getMatch();
+
+        // Check if countdown is complete (match has started)
+        // Countdown runs for the length of countdown messages (typically 5-6 seconds)
+        // We check if countdown is enabled and if match duration is less than countdown duration
+        if (match != null && config.isCdEnabled()) {
+            // Countdown messages are shown every second (20 ticks)
+            // Countdown duration = (number of messages - 1) * 1000ms
+            // The last message ("Now in a match") is shown AFTER countdown completes
+            // Add 500ms buffer to account for timing differences
+            final int countdownDuration = (config.getCdDuelMessages().size() - 1) * 1000 + 500;
+            if (match.getDurationInMillis() < countdownDuration) {
+                lang.sendMessage(player, "DUEL.leave.countdown-active");
+                return;
+            }
+        }
+
+        // Check if match is not in endgame phase
+        if (arena.isEndGame()) {
+            lang.sendMessage(player, "DUEL.leave.endgame-phase");
+            return;
+        }
+
+        plugin.doSyncAfter(() -> {
+            if (player.isOnline() && arenaManager.isInMatch(player)) {
+                player.setHealth(0);
+            }
+        }, 1L);
+    }
+}

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/core/DuelManager.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/core/DuelManager.java
@@ -7,6 +7,7 @@ import com.meteordevelopments.duels.core.arena.ArenaImpl;
 import com.meteordevelopments.duels.core.arena.ArenaManagerImpl;
 import com.meteordevelopments.duels.core.kit.edit.KitEditManager;
 import com.meteordevelopments.duels.core.match.DuelMatch;
+import com.meteordevelopments.duels.core.match.party.PartyDuelMatch;
 import com.meteordevelopments.duels.core.match.team.TeamDuelMatch;
 import com.meteordevelopments.duels.core.arena.fireworks.FireworkUtils;
 import com.meteordevelopments.duels.config.Config;
@@ -133,20 +134,23 @@ public class DuelManager implements Loadable {
                     handleWin(alivePlayer, loser, arena, match);
                 }
 
-                if (config.isEndCommandsEnabled() && !(!match.isFromQueue() && config.isEndCommandsQueueOnly())) {
-                    try {
-                        for (final String command : config.getEndCommands()) {
-                            String processedCommand = command
-                                    .replace("%winner%", winner.getName()).replace("%loser%", loser.getName())
-                                    .replace("%kit%", match.getKit() != null ? match.getKit().getName() : "").replace("%arena%", arena.getName())
-                                    .replace("%bet_amount%", String.valueOf(match.getBet()));
-                            
-                            executeCommandWithDelay(processedCommand);
-                        }
-                    } catch (Exception ex) {
-                        Log.warn(DuelManager.this, "Error while running match end commands: " + ex.getMessage());
+                Collection<Player> winnerPlayers = winners;
+                Collection<Player> loserPlayers = Collections.singleton(loser);
+
+                if (match instanceof PartyDuelMatch partyMatch) {
+                    final Party winnerParty = partyMatch.getPlayerToParty().get(winner);
+                    final Party loserParty = partyMatch.getPlayerToParty().get(loser);
+
+                    if (winnerParty != null) {
+                        winnerPlayers = new HashSet<>(partyMatch.getPartyToPlayers().get(winnerParty));
+                    }
+
+                    if (loserParty != null) {
+                        loserPlayers = new HashSet<>(partyMatch.getPartyToPlayers().get(loserParty));
                     }
                 }
+
+                runEndCommands(match, arena, winnerPlayers, loserPlayers);
 
                 arena.endMatch(winner.getUniqueId(), loser.getUniqueId(), Reason.OPPONENT_DEFEAT);
             }, config.getTeleportDelay() * 20L);
@@ -214,22 +218,7 @@ public class DuelManager implements Loadable {
                     handleTeamWin(winner, losers, arena, match);
                 }
 
-                if (config.isEndCommandsEnabled() && !(!match.isFromQueue() && config.isEndCommandsQueueOnly())) {
-                    try {
-                        for (final String command : config.getEndCommands()) {
-                            String winnerNames = winners.stream().map(Player::getName).collect(Collectors.joining(", "));
-                            String loserNames = losers.stream().map(Player::getName).collect(Collectors.joining(", "));
-                            String processedCommand = command
-                                    .replace("%winner%", winnerNames).replace("%loser%", loserNames)
-                                    .replace("%kit%", match.getKit() != null ? match.getKit().getName() : "").replace("%arena%", arena.getName())
-                                    .replace("%bet_amount%", String.valueOf(match.getBet()));
-                            
-                            executeCommandWithDelay(processedCommand);
-                        }
-                    } catch (Exception ex) {
-                        Log.warn(DuelManager.this, "Error while running match end commands: " + ex.getMessage());
-                    }
-                }
+                runEndCommands(match, arena, winners, losers);
 
                 arena.endMatch(winners.iterator().next().getUniqueId(), losers.iterator().next().getUniqueId(), Reason.OPPONENT_DEFEAT);
             }, config.getTeleportDelay() * 20L);
@@ -1011,5 +1000,45 @@ public class DuelManager implements Loadable {
             // No delay, execute immediately
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
         }
+    }
+
+    private void runEndCommands(final DuelMatch match, final ArenaImpl arena, final Collection<Player> winners,
+                                final Collection<Player> losers) {
+        if (!config.isEndCommandsEnabled() || (!match.isFromQueue() && config.isEndCommandsQueueOnly())) {
+            return;
+        }
+
+        try {
+            final String winnerNames = winners.stream().map(Player::getName).collect(Collectors.joining(", "));
+            final String loserNames = losers.stream().map(Player::getName).collect(Collectors.joining(", "));
+
+            for (final String command : config.getEndCommands()) {
+                for (final Player winner : winners) {
+                    executeCommandWithDelay(replaceEndCommandPlaceholders(command, winner, true, winnerNames, loserNames, match, arena));
+                }
+
+                for (final Player loser : losers) {
+                    executeCommandWithDelay(replaceEndCommandPlaceholders(command, loser, false, winnerNames, loserNames, match, arena));
+                }
+            }
+        } catch (Exception ex) {
+            Log.warn(DuelManager.this, "Error while running match end commands: " + ex.getMessage());
+        }
+    }
+
+    private String replaceEndCommandPlaceholders(final String command, final Player player, final boolean winnerSide,
+                                                 final String winnerNames, final String loserNames,
+                                                 final DuelMatch match, final ArenaImpl arena) {
+        final String playerName = player.getName();
+        final String winnerValue = winnerSide ? playerName : winnerNames;
+        final String loserValue = winnerSide ? loserNames : playerName;
+
+        return command
+                .replace("%player%", playerName)
+                .replace("%winner%", winnerValue)
+                .replace("%loser%", loserValue)
+                .replace("%kit%", match.getKit() != null ? match.getKit().getName() : "")
+                .replace("%arena%", arena.getName())
+                .replace("%bet_amount%", String.valueOf(match.getBet()));
     }
 }

--- a/duels-plugin/src/main/resources/config.yml
+++ b/duels-plugin/src/main/resources/config.yml
@@ -210,6 +210,7 @@ duel:
       queue-matches-only: false
 
       # Available placeholders:
+      # %player% - Name of the player the command is being run for
       # %winner% - Name of the winner of the match
       # %loser% - Name of the loser of the match
       # {delay:x} - Used to give x ms of delay before running any command

--- a/duels-plugin/src/main/resources/lang.yml
+++ b/duels-plugin/src/main/resources/lang.yml
@@ -519,7 +519,9 @@ DUEL:
       title: '&eYOU WON &6$%money%&e!'
     items:
       message: '{PREFIX} &7You have received &f%name%&7''s items for winning!'
-
+  leave:
+    countdown-active: '{PREFIX} &cYou cannot give up during countdown.'
+    endgame-phase: '{PREFIX} &cMatch is already ending.'
 
 PARTY:
   auto-disband:


### PR DESCRIPTION
- Implemented `LeaveCommand` to let players surrender during matches with conditions.
- Updated `lang.yml` with messages for countdown and endgame restrictions.
- Registered `LeaveCommand` in `DuelCommand`.
- Refactored end command logic for better handling of winners and losers in team/party duels. #318 
- Incremented project version to `7.4`.
- Updated reload logic #320 #313 