### PR TITLE
Restore PvPManager state after duels

### DIFF
--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/core/DuelManager.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/core/DuelManager.java
@@ -225,6 +225,7 @@ public class DuelManager implements Loadable {
         }
 
         endgameLeaveRequests.add(player.getUniqueId());
+        playerManager.restorePvP(player);
 
         final PlayerInfo info = playerManager.get(player);
         if (info != null) {
@@ -887,6 +888,7 @@ public class DuelManager implements Loadable {
         @EventHandler
         public void on(final PlayerQuitEvent event) {
             final Player player = event.getPlayer();
+            playerManager.restorePvP(player);
 
             if (!arenaManager.isInMatch(player) || endgameLeaveRequests.contains(player.getUniqueId())) {
                 return;

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/core/player/PlayerInfo.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/core/player/PlayerInfo.java
@@ -23,6 +23,8 @@ public class PlayerInfo {
     private final int level;
     private final int hunger;
     private final boolean restoreExperience;
+    @Setter
+    private Boolean pvpState; // Null when PvPManager was unavailable or loading an older cache.
     private final List<ItemStack> extra = new ArrayList<>();
     @Setter
     private Location location;

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/core/player/PlayerInfoManager.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/core/player/PlayerInfoManager.java
@@ -10,6 +10,7 @@ import com.meteordevelopments.duels.config.Config;
 import com.meteordevelopments.duels.data.LocationData;
 import com.meteordevelopments.duels.data.PlayerData;
 import com.meteordevelopments.duels.hook.hooks.EssentialsHook;
+import com.meteordevelopments.duels.hook.hooks.PvPManagerHook;
 import com.meteordevelopments.duels.core.match.team.TeamDuelMatch;
 import com.meteordevelopments.duels.core.teleport.Teleport;
 import com.meteordevelopments.duels.util.Loadable;
@@ -60,6 +61,7 @@ public class PlayerInfoManager implements Loadable {
 
     private Teleport teleport;
     private EssentialsHook essentials;
+    private PvPManagerHook pvpManager;
     private ArenaManagerImpl arenaManager;
 
     @Getter
@@ -80,6 +82,7 @@ public class PlayerInfoManager implements Loadable {
     public void handleLoad() throws IOException {
         this.teleport = plugin.getTeleport();
         this.essentials = plugin.getHookManager().getHook(EssentialsHook.class);
+        this.pvpManager = plugin.getHookManager().getHook(PvPManagerHook.class);
         this.arenaManager = plugin.getArenaManager();
 
         if (FileUtil.checkNonEmpty(cacheFile, false)) {
@@ -226,6 +229,9 @@ public class PlayerInfoManager implements Loadable {
      */
     public void create(final Player player, final boolean excludeInventory, final boolean restoreExperience) {
         final PlayerInfo info = new PlayerInfo(player, excludeInventory, restoreExperience);
+        if (pvpManager != null) {
+            info.setPvpState(pvpManager.getPvPState(player));
+        }
 
         if (!config.isTeleportToLastLocation()) {
             info.setLocation(lobby.clone());
@@ -250,7 +256,15 @@ public class PlayerInfoManager implements Loadable {
      * @return Removed PlayerInfo instance or null if not found
      */
     public PlayerInfo remove(final Player player) {
+        restorePvP(player);
         return cache.remove(player.getUniqueId());
+    }
+
+    public void restorePvP(final Player player) {
+        final PlayerInfo info = get(player);
+        if (pvpManager != null && info != null && info.getPvpState() != null) {
+            pvpManager.setPvPState(player, info.getPvpState());
+        }
     }
 
     private class PlayerInfoListener implements Listener {
@@ -303,6 +317,8 @@ public class PlayerInfoManager implements Loadable {
                 }
             }
 
+            // Restore before respawning outside the arena, not in the delayed inventory task.
+            restorePvP(player);
             event.setRespawnLocation(info.getLocation());
 
             if (essentials != null) {

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/data/PlayerData.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/data/PlayerData.java
@@ -18,6 +18,7 @@ public class PlayerData {
     private int hunger;
     private LocationData location;
     private boolean restoreExperience;
+    private Boolean pvpState;
     private List<ItemData> extra = new ArrayList<>();
     private PlayerData() {
     }
@@ -29,6 +30,7 @@ public class PlayerData {
         this.hunger = info.getHunger();
         this.location = LocationData.fromLocation(info.getLocation());
         this.restoreExperience = info.isRestoreExperience();
+        this.pvpState = info.getPvpState();
 
         for (final Map.Entry<String, Map<Integer, ItemStack>> entry : info.getItems().entrySet()) {
             final Map<Integer, ItemData> data = new HashMap<>();
@@ -56,6 +58,8 @@ public class PlayerData {
                 location.toLocation(),
                 restoreExperience
         );
+
+        info.setPvpState(pvpState);
 
         for (final Map.Entry<String, Map<Integer, ItemData>> entry : items.entrySet()) {
             final Map<Integer, ItemStack> data = new HashMap<>();

--- a/duels-plugin/src/main/java/com/meteordevelopments/duels/hook/hooks/PvPManagerHook.java
+++ b/duels-plugin/src/main/java/com/meteordevelopments/duels/hook/hooks/PvPManagerHook.java
@@ -32,6 +32,18 @@ public class PvPManagerHook extends PluginHook<DuelsPlugin> {
         Bukkit.getPluginManager().registerEvents(new PvPManagerListener(), plugin);
     }
 
+    public Boolean getPvPState(final Player player) {
+        final CombatPlayer pvPlayer = CombatPlayer.get(player);
+        return pvPlayer != null ? pvPlayer.hasPvPEnabled() : null;
+    }
+
+    public void setPvPState(final Player player, final boolean state) {
+        final CombatPlayer pvPlayer = CombatPlayer.get(player);
+        if (pvPlayer != null) {
+            pvPlayer.setPvP(state);
+        }
+    }
+
     public boolean isTagged(final Player player) {
         if (config.isPmPreventDuel()) {
             return false;


### PR DESCRIPTION
Players who enter a duel with `/pvp off` can leave with PvP still enabled. On our server, players exploit this by challenging newcomers to a duel, then asking them to teleport somewhere and killing them while they believe PvP is still disabled.

This saves their original PvP state and restores it when they leave, respawn, or disconnect.
